### PR TITLE
fixed recipe for use inside of media-queries (removes use of @extend) and add github style

### DIFF
--- a/stylesheets/recipes/effect/_ribbon.scss
+++ b/stylesheets/recipes/effect/_ribbon.scss
@@ -60,15 +60,75 @@
 
     @if ($skin == 'classic')
     {
-        @extend %effect-ribbon-skin-classic;
+        $color: #fff;
+        $border-width: 1px;
+        $border-color: #631a15;
+        $border-dot-subcolor: #da5050;
+        $border-dot-offset: 3px;
+
+        color: $color;
+        text-shadow: 0 1px 0 rgba(#000, .8);
+
+        border: $border-width solid $border-color;
+
+        background: rgb(199,59,60); //fallback
+        @include background(linear-gradient(rgb(199,59,60),rgb(184,32,31)));
+        box-shadow: 0 .2em .6em rgba(#000, .6);
+
+        // todo replace this use of pseudo elements by appropriate backgrounds properties (tricky gradients)
+        &:before,
+        &:after {
+            @include pseudo-element(100%, 0);
+            border: $border-width dashed;
+            border-left: 0;
+            border-right: 0;
+            border-top-color: $border-color;
+            border-bottom-color: $border-dot-subcolor;
+        }
+
+        &:before { top: $border-dot-offset; }
+        &:after { bottom: $border-dot-offset - $border-width *2; }
+
         // skin border size to remove;
         $width-add: .1em;
         $height-add: .1em;
     }
-    //@elseif ($skin == 'github')
-    //{
-    //    @extend %effect-ribbon-skin-github;
-    //}
+
+    @elseif ($skin == 'github')
+    {
+        $color: #fff;
+        $border-width: 1px;
+        $border-color: #007200;
+        $border-dot-subcolor: #fff;
+        $border-dot-offset: 3px;
+
+        color: $color;
+        text-shadow: 0 1px 0 rgba(#000, .8);
+
+        border: $border-width solid $border-color;
+
+        background: rgb(1,115,1); //fallback
+        @include background(linear-gradient(rgb(1,115,1),rgb(35,131,35)));
+        box-shadow: 0 .2em .6em rgba(#000, .6);
+
+        // todo replace this use of pseudo elements by appropriate backgrounds properties (tricky gradients)
+        &:before,
+        &:after {
+            @include pseudo-element(100%, 0);
+            border: $border-width dashed;
+            border-left: 0;
+            border-right: 0;
+            border-top-color: $border-color;
+            border-bottom-color: $border-dot-subcolor;
+        }
+
+        &:before { top: $border-dot-offset - $border-width *2; }
+        &:after { bottom: $border-dot-offset - $border-width *2; }
+
+        // skin border size to remove;
+        $width-add: .1em;
+        $height-add: .1em;
+    }
 
     // here is the awesome trick !
     $value: pow($width + $width-add, 2) / 2 ;
@@ -81,34 +141,6 @@
 
 %effect-ribbon-skin-classic
 {
-    $color: #fff;
-    $border-width: 1px;
-    $border-color: #631a15;
-    $border-dot-subcolor: #da5050;
-    $border-dot-offset: 3px;
-
-    color: $color;
-    text-shadow: 0 1px 0 rgba(#000, .8);
-
-    border: $border-width solid $border-color;
-
-    background: rgb(199,59,60); //fallback
-    @include background(linear-gradient(rgb(199,59,60),rgb(184,32,31)));
-    box-shadow: 0 .2em .6em rgba(#000, .6);
-
-    // todo replace this use of pseudo elements by appropriate backgrounds properties (tricky gradients)
-    &:before,
-    &:after {
-        @include pseudo-element(100%, 0);
-        border: $border-width dashed;
-        border-left: 0;
-        border-right: 0;
-        border-top-color: $border-color;
-        border-bottom-color: $border-dot-subcolor;
-    }
-
-    &:before { top: $border-dot-offset; }
-    &:after { bottom: $border-dot-offset - $border-width *2; }
 }
 
 // @todo ?


### PR DESCRIPTION
I can clean this if it's too dirty.  I am actually not very familiar with sass at all and went down this path just for the simple task of getting some working ribbon css.  

It turns out the CSS looked great on either a big screen or mobile but not both; and attempting to put the @include inside a @media was giving 

```
DEPRECATION WARNING on line 63 of [snip]compass-recipes/stylesheets/recipes/effect/_ribbon.scss:
  @extending an outer selector from within @media is deprecated.
  You may only @extend selectors within the same directive.
  This will be an error in Sass 3.3.
  It can only work once @extend is supported natively in the browser.
```

This warning was busting my workflow so I just 'unrolled' the @extend.

While I was at it, I took my first shot at the gitub style... which really should just be called 'green classic' or whatever now that I look at it.
